### PR TITLE
Fix Album Art

### DIFF
--- a/jukeos/package-lock.json
+++ b/jukeos/package-lock.json
@@ -6823,9 +6823,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8809,9 +8809,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -8833,7 +8833,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -8848,6 +8848,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -13627,9 +13631,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -14180,9 +14184,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/path-type": {

--- a/jukeos/src/App.css
+++ b/jukeos/src/App.css
@@ -426,15 +426,6 @@ html, body, #root {
   z-index: 1;
 }
 
-.album-glow{
-  position: relative;
-  width: 600px;
-  height: 600px;
-  display: flex;
-
-}
-
-
 @media (max-width: 800px) {
   .album-art {
     width: 50vw;

--- a/jukeos/src/App.css
+++ b/jukeos/src/App.css
@@ -414,3 +414,31 @@ html, body, #root {
              floatClouds 20s ease-in-out infinite;
   filter: blur(1px);
 }
+
+.album-art{
+  width: 30vw;
+  max-width: 500px;
+  height: auto;
+  object-fit: cover;
+  border-radius: 15px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  position: relative;
+  z-index: 1;
+}
+
+.album-glow{
+  position: relative;
+  width: 600px;
+  height: 600px;
+  display: flex;
+
+}
+
+
+@media (max-width: 800px) {
+  .album-art {
+    width: 50vw;
+    max-width: 250px;
+  }
+}
+

--- a/jukeos/src/components/Home.js
+++ b/jukeos/src/components/Home.js
@@ -252,7 +252,7 @@ const Home = () => {
             gap: '10px',
             width: '500px'
           }}>
-            <h1 style={{ 
+            <h1 style={{
               fontFamily: 'Loubag, sans-serif',
               fontSize: '5rem',
               margin: '0',
@@ -268,7 +268,7 @@ const Home = () => {
               {track?.name|| "Unknown"}
             </h1>
 
-            <h2 style={{ 
+            <h2 style={{
               fontFamily: 'Notable, sans-serif',
               fontSize: '2rem',
               margin: '0',
@@ -296,7 +296,7 @@ const Home = () => {
               width: '100%',
               marginTop: '10px'
             }}>
-              <div 
+              <div
                 style={{
                   width: '100%',
                   height: '4px',
@@ -318,7 +318,7 @@ const Home = () => {
               </div>
             </div>
 
-            <button 
+            <button
               onClick={() => togglePlay()}
               style={{
                 background: 'transparent',
@@ -330,8 +330,8 @@ const Home = () => {
                 margin: '10px auto'
               }}
             >
-              <img 
-                src={paused ? playIcon : pauseIcon} 
+              <img
+                src={paused ? playIcon : pauseIcon}
                 alt={paused ? "Play" : "Pause"}
                 style={{
                   width: '100%',
@@ -343,40 +343,33 @@ const Home = () => {
             </button>
           </div>
 
-          <div style={{ 
-            position: 'relative', 
+          <div style={{
+            position: 'relative',
             width: '600px',
-            height: '600px', 
+            height: '600px',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center'
           }}>
-            <AnimatedBlob 
-              colors={['#ECE0C4', 'rgba(236, 224, 196, 0.5)']} 
-              style={{
-                width: '600px',
-                height: '600px',
-                top: '-20px',
-                left: '0'
-              }}
-              static={true}
+            <AnimatedBlob
+                colors={['#ECE0C4', 'rgba(236, 224, 196, 0.5)']}
+                style={{
+                  width: '600px',
+                  height: '600px',
+                  top: '-20px',
+                  left: '0'
+                }}
+                static={true}
             />
-            <img 
-              src={track?.album?.images?.[0]?.url || '../assets/default-album-art.png'} 
-              alt="Album Art" 
-              style={{
-                width: '500px',
-                height: '500px',
-                borderRadius: '15px',
-                boxShadow: '0 4px 20px rgba(0,0,0,0.5)',
-                position: 'relative',
-                zIndex: 1
-              }} 
+            <img
+                src={track?.album?.images?.[0]?.url || './web-app-manifest-512x512.png'}
+                alt="Album Art"
+                className="album-art"
             />
           </div>
         </div>
         <div style={{
-          width: '500px',  
+          width: '500px',
           marginTop: '-240px',
           alignSelf: 'flex-start',
           paddingLeft: '0'


### PR DESCRIPTION
Closes #73 

I went and fixed the default album art. I just set it to one of our Favicons because it was the right aspect ratio (it is low res though). If someone has a better image to use with the right aspect ratio go ahead and change it. I just need an image for development purposes. 

Next I made it so that the album art now scales with screen resolution. It is currently made with a media query and utilizes view ports so the intermediary resolutions between 2560x1440 and 800x460 might look a little funky but it looks pretty good for just those two resolutions.

Finally I also ran NPM audit fix to try resolve some of our NPM vulnerabilities and just committed those so we stay kinda on top of those.

When you run it locally you will quickly notice the color gradient background does not scale. This is something I thought should be tackled in a different PR (it was also giving me a ton of problems). Also sorry about all the whitespace changes. Will try to make it so it wont always do that.