### PR TITLE
Nav Bar Glow Gradient

### DIFF
--- a/jukeos/src/App.css
+++ b/jukeos/src/App.css
@@ -100,8 +100,6 @@
 
 .navbar a.active {
   opacity: 1;
-  color: #ECE0C4;
-  text-shadow: 0 0 20px rgba(255, 215, 0, 0.7), 0 0 30px rgba(255, 215, 0, 0.5), 0 0 40px rgba(255, 215, 0, 0.3), 3px 3px 5px rgba(0, 0, 0, 0.7);
 }
 
 .spotlight {

--- a/jukeos/src/App.js
+++ b/jukeos/src/App.js
@@ -39,8 +39,8 @@ function AppContent({ isLoading }) {
   return (
     <ProvideSpotifyAuthContext>
       <StartupScreen isLoading={isLoading} />
-      <NavigationBar />
       <Player>
+        <NavigationBar />
         <div className="page-content">
           <AnimatePresence mode="wait">
             <Routes location={location} key={location.pathname}>

--- a/jukeos/src/components/Home.js
+++ b/jukeos/src/components/Home.js
@@ -389,7 +389,7 @@ const Home = () => {
             />
             <img 
               src={track?.album?.images?.[0]?.url || defaultAlbumArt} 
-              alt="Album Art" 
+              alt="Album Art"
               className={"album-art"}
             />
           </div>

--- a/jukeos/src/components/NavigationBar.js
+++ b/jukeos/src/components/NavigationBar.js
@@ -1,14 +1,10 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { SpotifyAuthContext, performFetch } from '../contexts/spotify';
-
-import axios from 'axios';
 import ColorThief from 'color-thief-browser';
-
 import AnimatedBlob from './AnimatedBlob';
-import spotlightPng from '../assets/spotlight.png';
-import {useColorThief} from "./Home";
-
+import {PlayerContext} from "./Player";
+import defaultAlbumArt from "../assets/default-art-placeholder.svg";
 
 const NavigationBar = () => {
   const navbarContentRef = useRef(null);
@@ -16,10 +12,14 @@ const NavigationBar = () => {
   const [animationInProgress, setAnimationInProgress] = useState(false);
   const [isFlickering, setIsFlickering] = useState(false);
   const [dominantColors, setDominantColors] = useState(['#4CAF50', '#2196F3']);
+  const [dominantRGBA,setDominantRGBA] = useState("");
   const {accessToken, invalidateAccess} = useContext(SpotifyAuthContext);
   const [profilePicture, setProfilePicture] = useState(require("../assets/default-user-profile-image.svg").default);
   const navigate = useNavigate();
+  const { track} = useContext(PlayerContext);
 
+  //Same function as useColorThief
+  //TODO useColorThief instead of logic in component
   const extractDominantColors = (imageSrc) => {
     const img = new Image();
     img.crossOrigin = 'Anonymous';
@@ -28,13 +28,16 @@ const NavigationBar = () => {
     img.onload = () => {
       const colorThief = new ColorThief();
       const palette = colorThief.getPalette(img, 2);
+      //Set two different RGB formats.
+      setDominantRGBA(palette.map(color => `rgba(${color[0]}, ${color[1]}, ${color[2]},0.9)`));
       setDominantColors(palette.map(color => `rgb(${color[0]}, ${color[1]}, ${color[2]})`));
+      //TODO Further investigate color scaling so it matches the background better
     };
   };
-
   useEffect(() => {
-    extractDominantColors(require('../assets/default-user-profile-image.svg').default);
-  }, []);
+    extractDominantColors(track?.album?.images[0]?.url || defaultAlbumArt)
+  }, [track]);
+
 
   useEffect(() => {
     if (navbarContentRef.current && !animationInProgress) {
@@ -45,10 +48,10 @@ const NavigationBar = () => {
         const navbarWidth = navbarContentRef.current.offsetWidth;
         const activeLinkCenter = activeLink.offsetLeft + activeLink.offsetWidth / 2;
         const offset = navbarWidth / 2 - activeLinkCenter;
-        
+
         navbarContentRef.current.style.transition = 'transform 800ms cubic-bezier(0.34, 1.56, 0.64, 1)';
         navbarContentRef.current.style.transform = `translateX(${offset}px)`;
-        
+
         setTimeout(() => {
           setAnimationInProgress(false);
           setIsFlickering(false);
@@ -77,13 +80,10 @@ const NavigationBar = () => {
           const linkCenter = link.offsetLeft + link.offsetWidth / 2;
           const distance = Math.abs(activeLinkCenter - linkCenter);
           const normalizedDistance = distance / (totalWidth / 2); // Value between 0 and 1
-          
           link.style.transition = 'filter 800ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 800ms cubic-bezier(0.34, 1.56, 0.64, 1)';
-          
           // More subtle blur calculation
           const blurAmount = Math.pow(normalizedDistance, 2) * 2; // Reduced max blur and made more gradual
           const opacity = Math.max(0.4, 1 - Math.pow(normalizedDistance, 1.5)); // Minimum opacity of 0.4
-          
           link.style.filter = `blur(${blurAmount}px)`;
           link.style.opacity = opacity;
         });
@@ -124,10 +124,23 @@ const NavigationBar = () => {
       <nav className="navbar">
         <div className="navbar-blur-container">
           <div className="navbar-content" ref={navbarContentRef}>
-            <NavLink to="/harmony">Harmony</NavLink>
-            <NavLink to="/" end>Home</NavLink>
-            <NavLink to="/library">Library</NavLink>
-            <NavLink to="/settings">Settings</NavLink>
+            {['/harmony', '/', '/library', '/settings'].map((path, index) => (
+                <NavLink
+                    key={path}
+                    to={path}
+                    end={path === '/'}
+                    style={({ isActive }) =>
+                        isActive
+                            ? {
+                              color: '#ECE0C4',
+                              textShadow: `0 0 20px ${dominantRGBA[0]}, 0 0 25px ${dominantRGBA[1]}, 0 0 35px ${dominantRGBA[2]}`
+                            }
+                            : {}
+                    }
+                >
+                  {path.replace('/', '') || 'Home'}
+                </NavLink>
+            ))}
             <NavLink to="/profile" className="profile-link">Profile</NavLink>
           </div>
         </div>
@@ -144,7 +157,6 @@ const NavigationBar = () => {
             src={profilePicture}
             alt="User Profile"
             className="user-profile-image"
-            onLoad={(e) => extractDominantColors(e.target.src)}
             onClick={() => navigate('/profile')}
           />
         </div>


### PR DESCRIPTION
Closes #115 
Closes #116 

This now moves the glow gradient (similar to what we have from #108) to the nav bar text moving away from the static yellow glow we have currently. These gradients don't always mix well with our current color scheme but more often then not it looks pretty good. A big part of this PR was getting the data from the player context to the navigation bar. The nav bar was improperly placed in App.js and the track data was never being set inside of the context provider. This made it really tricky to debug since there were two issues going on at the same time. 

Some plans moving forward: 

I need to refactor the navigation bar to use the hook I created in Home.js (useColorThief)
We need to maybe rethink the logic inside the player listeners. 
Possibly scale the color used on the glow for the nav bar.