### PR TITLE
Fix Spotify Player initialization error on first load

### DIFF
--- a/jukeos/src/components/Player.js
+++ b/jukeos/src/components/Player.js
@@ -14,46 +14,50 @@ const Player = ({ children }) => {
 
   //TODO Refactor a lot of this listener logic
   useEffect(() => {
-    if (accessToken && playbackReady && !player) {
+    if (accessToken && playbackReady && !player && window.Spotify) {
       console.log("Constructing player");
 
-      // eslint-disable-next-line no-undef
-      const p = new Spotify.Player({
-        name: "Juke Spotify Player",
-        getOAuthToken: (callback) => callback(accessToken)
-      });
-
-      setPlayer(p);
-
-      p.addListener("ready", ({ device_id }) => {
-        setDeviceId(device_id);
-
-        p.getCurrentState().then((state) => {
-          console.log("Id State", state);
+      try {
+        // eslint-disable-next-line no-undef
+        const p = new Spotify.Player({
+          name: "Juke Spotify Player",
+          getOAuthToken: (callback) => callback(accessToken)
         });
 
-        setOnline(true);
-      });
+        setPlayer(p);
 
-      p.addListener("not_ready", ({ device_id }) => {
-        setDeviceId(device_id);
+        p.addListener("ready", ({ device_id }) => {
+          setDeviceId(device_id);
 
-        setOnline(false);
-      });
+          p.getCurrentState().then((state) => {
+            console.log("Id State", state);
+          });
 
-      p.addListener('initialization_error', ({ message }) => {
-        console.error(message);
-      });
+          setOnline(true);
+        });
 
-      p.addListener('authentication_error', ({ message }) => {
-        console.error(message);
-      });
+        p.addListener("not_ready", ({ device_id }) => {
+          setDeviceId(device_id);
 
-      p.addListener('account_error', ({ message }) => {
-        console.error(message);
-      });
+          setOnline(false);
+        });
 
-      p.connect();
+        p.addListener('initialization_error', ({ message }) => {
+          console.error(message);
+        });
+
+        p.addListener('authentication_error', ({ message }) => {
+          console.error(message);
+        });
+
+        p.addListener('account_error', ({ message }) => {
+          console.error(message);
+        });
+
+        p.connect();
+      } catch (error) {
+        console.error("Error initializing Spotify player:", error);
+      }
     }
   }, [accessToken, playbackReady, player]);
 


### PR DESCRIPTION
This PR fixes the "Script error" that occurs when the application first loads. The error was happening because the Player component was attempting to initialize the Spotify Web Playback SDK before it was fully loaded and available in the window object.

### Changes Made
- Added a check for window.Spotify to ensure the SDK exists before attempting to use it
- Wrapped the initialization code in a try/catch block to gracefully handle any initialization errors
- Added improved error logging to capture specific error details instead of the generic "Script error"

Resolves #131 - "Script error" on first load with Spotify Player initialization

### How to Test
1. Launch the application (npm start)
2. Verify that no "Script error" appears in the console on first load
3. Confirm that the Spotify player still initializes correctly
4. Check that you can still play music through the Spotify player after initialization