### PR TITLE
fix: correctly load Spotify API credentials from root .env file

### DIFF
--- a/jukeos/src/auth-server/server.js
+++ b/jukeos/src/auth-server/server.js
@@ -4,7 +4,15 @@ const axios = require('axios');
 const cors = require('cors');
 
 // NOTE: This is a hack because node is evoked in src/auth-server
-require('dotenv').config({ path: `${__dirname}/../.env` });
+require('dotenv').config({ path: `${__dirname}/../../.env` });
+
+if (!process.env.SPOTIFY_CLIENT_ID || !process.env.SPOTIFY_CLIENT_SECRET) {
+  console.error('ERROR: Spotify client credentials are missing. Please set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET environment variables.');
+  process.exit(1); // Exit the process with an error code
+}
+
+const ClientId = process.env.SPOTIFY_CLIENT_ID;
+const ClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
 
 const app = express();
 const port = 3001;
@@ -12,12 +20,13 @@ const port = 3001;
 app.use(bodyParser.json());
 app.use(express.urlencoded({ extended: true }));
 
-const ClientId = process.env.SPOTIFY_CLIENT_ID;
-const ClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
-
 app.use(cors());
 
 app.get('/login/spotify', async (req, res) => {
+  if (!ClientId || ClientId === 'undefined') {
+    return res.status(400).send('Spotify client ID not configured. Please check your environment variables.');
+  }
+  
   const params = new URLSearchParams();
   params.append("client_id", ClientId);
   params.append("response_type", "code");
@@ -32,6 +41,10 @@ app.get('/login/spotify', async (req, res) => {
 });
 
 app.post('/refresh/spotify', (req, res) => {
+  if (!ClientId || ClientId === 'undefined') {
+    return res.status(500).send('Spotify client ID not configured. Please check your environment variables.');
+  }
+  
   if (!req.body.refresh_token) {
     res.status(400).send('juke_refresh_token_not_defined');
   } else {
@@ -61,6 +74,10 @@ app.post('/refresh/spotify', (req, res) => {
 });
 
 app.get('/callback/spotify', (req, res) => {
+  if (!ClientId || ClientId === 'undefined') {
+    return res.status(500).send('Spotify client ID not configured. Please check your environment variables.');
+  }
+  
   if (!req.query.code) {
     res.status(400).send(req.query.error || "juke_unknown_error");
   } else {

--- a/jukeos/src/auth-server/server.js
+++ b/jukeos/src/auth-server/server.js
@@ -41,9 +41,6 @@ app.get('/login/spotify', async (req, res) => {
 });
 
 app.post('/refresh/spotify', (req, res) => {
-  if (!ClientId || ClientId === 'undefined') {
-    return res.status(500).send('Spotify client ID not configured. Please check your environment variables.');
-  }
   
   if (!req.body.refresh_token) {
     res.status(400).send('juke_refresh_token_not_defined');
@@ -74,9 +71,6 @@ app.post('/refresh/spotify', (req, res) => {
 });
 
 app.get('/callback/spotify', (req, res) => {
-  if (!ClientId || ClientId === 'undefined') {
-    return res.status(500).send('Spotify client ID not configured. Please check your environment variables.');
-  }
   
   if (!req.query.code) {
     res.status(400).send(req.query.error || "juke_unknown_error");


### PR DESCRIPTION
Users (like me) were experiencing intermittent "INVALID_CLIENT" errors when logging in with Spotify. The auth server couldn't reliably access the Spotify API credentials stored in the root .env file. Issue was persistent in both Safari and Arc (Chromium-based browser).

Resolves issue https://github.com/tennitech/juke/issues/130.

### Solution
- Updated the dotenv configuration path to correctly load environment variables from project root
- Added validation checks to prevent API calls with undefined credentials
- Improved error messaging to help diagnose configuration issues

### How to Test

1. **Verify Server Startup**
- Run `npm start` and confirm no environment variable errors in console
- Server should log "Auth server running on http://localhost:3001"

2. **Test Login Flow**
- Click "Login with Spotify" button on the profile page
- Should redirect to Spotify authorization page (not error page)
- After authorizing, should redirect back to app and display user profile

3. **Test Token Refresh**
- Login with Spotify
- In browser developer tools, run this in console to invalidate the token: `localStorage.setItem('spotify_expires', '1');`
- Perform an action that requires authentication (like loading playlists)
- App should automatically refresh token without errors

4. **Test Error Handling**
- Temporarily rename .env file to .env.backup
- Restart server
- Try to login - should show helpful error message about missing credentials
- Restore .env file and restart server

### Notes
No changes to the authentication flow itself, just fixing the environment variable access
Added validation to prevent exposing undefined client IDs to Spotify's authorization endpoint