### PR TITLE
Automatically add 2 "random" songs to the queue if the queue is empty

### DIFF
--- a/jukeos/src/components/Player.js
+++ b/jukeos/src/components/Player.js
@@ -133,6 +133,9 @@ const Player = ({ children }) => {
     }
   }, [accessToken]);
 
+  // Mutex to prevent simultaneous player state events from adding to queue multiple times
+  let addingQueue = false;
+
   //Use effect to keep track of the current Track.
   useEffect(() => {
     if (!player) return;
@@ -145,39 +148,42 @@ const Player = ({ children }) => {
           console.log(state);
           setPaused(state.paused);
           setActive(!!state);
-          
-          // TODO: Find a better way to ensure the tracks only get added once
-          // or get spotify to stop sending 3-4 player state changes for some reason whenever a track starts playing
-          if (state.track_window.next_tracks.length == 0 && (state.loading || state.position == 0)) {
-            // TODO: Get 5 similar song recommendations from Harmony
+
+          if (state.track_window.next_tracks.length == 0 && !addingQueue) {
+            addingQueue = true;
+            // TODO: Get 2 similar song recommendations from Harmony
             // let songs = queryHarmony(state.track_window.current_track, recentlyPlayed);
             // For now, hard code in the top 5 songs on spotify right now
-            // TODO: Tweak the search query to give the best results
             // Seems like spotify only lets us add up to 2 songs at a time without encountering strange bugs
+            
             let songs = [
               "Lady Gaga, Bruno Mars - Die With A Smile",
-              // "ROSÉ, Bruno Mars - APT.",
+              "ROSÉ, Bruno Mars - APT.",
               "Billie Eilish - BIRDS OF A FEATHER",
-              // "Doechii - Anxiety",
-              // "Alex Warren - Ordinary"
+              "Doechii - Anxiety",
+              "Alex Warren - Ordinary"
             ];
 
+            var song1 = songs[Math.floor(Math.random() * songs.length)];
+            var song2 = songs[Math.floor(Math.random() * songs.length)];
+            songs = songs.filter((song) => song == song1 || song == song2);
+
             // BUG: Upon app startup, media controls seem to not work until
-            // You comment out the promise code below, save, and then uncomment and save (???)
+            // You make a change and save the file (?)
             let songPromises = songs.map(async (song) => {
-              let [artist_str, songTitle] = song.split(" - ");
-              let query = `${songTitle.toLowerCase()} ${artist_str.toLowerCase().replace(",", "")}`;
+              // let [artist_str, songTitle] = song.split(" - ");
+              // let query = `${songTitle.toLowerCase()} ${artist_str.toLowerCase().replace(",", "")}`;
               // console.log(query);
               try {
                 const response = await performFetch(
-                  `https://api.spotify.com/v1/search?q=${query}&type=track&limit=1`,
+                  `https://api.spotify.com/v1/search?q=${song}&type=track&limit=1`,
                   {},
                   accessToken,
                   invalidateAccess
                 );
 
                 if (response.tracks.items.length === 0) {
-                  console.error("No results found for query:", query);
+                  console.error("No results found for query:", song);
                   return "";
                 }
 
@@ -199,9 +205,9 @@ const Player = ({ children }) => {
               }
             });
 
-            // Promise.all(songPromises).then((songUris) => {
-            //   console.log(songUris);
-            // });
+            Promise.all(songPromises).then(() => {
+              addingQueue = false;
+            });
           }
         }
       }).catch((err) => console.error("Error getting player state:", err));

--- a/jukeos/src/components/Player.js
+++ b/jukeos/src/components/Player.js
@@ -142,7 +142,54 @@ const Player = ({ children }) => {
         if (state && state.track_window.current_track) {
           setTrack(state.track_window.current_track);
           console.log("Setting Track: " + JSON.stringify(state.track_window.current_track));
+
           // console.log(recentlyPlayed);
+
+          // TODO: get the queue
+          // if (queue.length == 0)
+          // TODO: Get 5 similar song recommendations from Harmony
+          // let songs = queryHarmony(state.track_window.current_track, recentlyPlayed);
+          // For now, hard code in the top 5 songs on spotify right now
+          // TODO: Tweak the search query to give the best results
+          let songs = [
+            "Lady Gaga, Bruno Mars - Die With A Smile",
+            "ROSÉ, Bruno Mars - APT.",
+            "Billie Eilish - BIRDS OF A FEATHER",
+            "Doechii - Anxiety",
+            "Alex Warren - Ordinary"
+          ];
+
+          let songPromises = songs.map(async (song) => {
+            let [artist_str, songTitle] = song.split(" - ");
+            let query = `${songTitle.toLowerCase()} ${artist_str.toLowerCase().replace(",", "")}`;
+            // console.log(query);
+            try {
+              const response = await performFetch(
+                `https://api.spotify.com/v1/search?q=${query}&type=track&limit=1`,
+                {},
+                accessToken,
+                invalidateAccess
+              );
+
+              if (response.tracks.items.length === 0) {
+                console.error("No results found for query:", query);
+                return "";
+              }
+
+              console.log("URL: ", response.tracks.items[0].external_urls.spotify);
+              console.log("popularity: ", response.tracks.items[0].popularity);
+              return response.tracks.items[0].external_urls.spotify;
+            } catch (err) {
+              console.error("Error getting recommendations:", err);
+              return "";
+            }
+          });
+
+          Promise.all(songPromises).then((songUrls) => {
+            songUrls = songUrls.filter((url) => url !== "");
+            console.log(songUrls);
+            
+          });
           setPaused(state.paused);
           setActive(!!state);
         }

--- a/jukeos/src/contexts/spotify.js
+++ b/jukeos/src/contexts/spotify.js
@@ -77,6 +77,32 @@ export async function performFetch(
     }
 }
 
+export async function performPost(
+    url, params, body,
+    accessToken, invalidateAccess
+) {
+    try {
+        const response = await axios.post(url, body, {
+            headers: {
+                "Authorization": "Bearer " + accessToken
+            },
+            params
+        });
+
+        return response?.data;
+    } catch (err) {
+        if (err.response) {
+            if (err.response.status === 401) {
+                return await performPost(
+                    url, params, body, accessToken, await invalidateAccess()
+                );
+            }
+        }
+
+        throw err;
+    }
+}
+
 export async function performPut(
     url, params, body,
     accessToken, invalidateAccess


### PR DESCRIPTION
- Automatically adds 2 randomly picked songs from the top 5 most popular songs on Spotify (hardcoded as of April 1, 2025).
- Addresses #110 
- In the future, Harmony will use Gemini to pick the songs based on recently played rather than using hardcoded songs.
- This merges into `144-recently-played-ctx`: I will remove some `console.log`s before merging that branch into main later.