### PR TITLE
Add Shuffle and loop buttons

### DIFF
--- a/jukeos/src/components/Home.js
+++ b/jukeos/src/components/Home.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect, useRef } from 'react';
+import React, {useContext, useState, useEffect, useRef, useCallback} from 'react';
 import { SpotifyAuthContext, performFetch, performPut } from '../contexts/spotify';
 import { PlayerContext } from './Player';
 import defaultAlbumArt from '../assets/default-art-placeholder.svg';
@@ -10,6 +10,7 @@ import pauseIcon from '../assets/pause-icon.svg';
 import ColorThief from "color-thief-browser";
 import nextIcon from "../assets/skip-forward-icon.svg"
 import prevIcon from "../assets/skip-backward-icon.svg"
+import shuffleIcon from "../assets/shuffle-icon.svg";
 
 //Move location possibly in the future
 export function useColorThief(imageSrc) {
@@ -44,6 +45,7 @@ const Home = () => {
     duration: 1
   });
   const [recentlyPlayed, setRecentlyPlayed] = useState([]);
+  const [shuffle, setShuffle] = useState(false);
 
   const formatTime = (seconds) => {
     const minutes = Math.floor(seconds / 60);
@@ -124,6 +126,14 @@ const Home = () => {
         })
     }
   };
+
+    const toggleShuffle = useCallback(() => {
+        setShuffle(!shuffle);
+        console.log("Shuffle toggled: " + shuffle);
+        performPut("https://api.spotify.com/v1/me/player/shuffle", {shuffle}, null,
+            accessToken, invalidateAccess); //There is no response
+    }, [shuffle]);
+  
 
   useEffect(() => {
     if (accessToken) {
@@ -302,86 +312,123 @@ const Home = () => {
               </div>
             </div>
 
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: '2vw',
-                marginTop: 'clamp(2vh, 3vh, 4vh)',
-                marginBottom: 'clamp(4vh, 6vh, 10vh)',
-                maxHeight: '80px'
-              }}
-            >
-              <button
-                onClick={() => prevTrack()}
-                style={{
-                  background: 'transparent',
-                  border: 'none',
-                  cursor: 'pointer',
-                  padding: '0',
-                  width: 'clamp(35px, 4vw, 50px)',
-                  height: 'clamp(35px, 4vw, 50px)'
-                }}
-              >
-                <img
-                  src={prevIcon}
-                  alt="Previous"
+              <div
                   style={{
-                    width: '100%',
-                    height: '100%',
-                    opacity: 0.8,
-                    transition: 'opacity 0.2s ease'
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between', // Space out shuffle vs rest
+                      marginTop: 'clamp(2vh, 3vh, 4vh)',
+                      marginBottom: 'clamp(4vh, 6vh, 10vh)',
+                      maxHeight: '80px',
                   }}
-                />
-              </button>
+              >
 
-              <button
-                onClick={() => togglePlay()}
-                style={{
-                  background: 'transparent',
-                  border: 'none',
-                  cursor: 'pointer',
-                  padding: '0',
-                  width: 'clamp(45px, 5vw, 70px)',
-                  height: 'clamp(45px, 5vw, 70px)'
-                }}
-              >
-                <img
-                  src={paused ? playIcon : pauseIcon}
-                  alt={paused ? "Play" : "Pause"}
-                  style={{
-                    width: '100%',
-                    height: '100%',
-                    opacity: 0.8,
-                    transition: 'opacity 0.2s ease'
-                  }}
-                />
-              </button>
+                  {/* Left-aligned Shuffle Button */}
+                  <button
+                      onClick={() => toggleShuffle()}
+                      style={{
+                          background: 'transparent',
+                          border: 'none',
+                          cursor: 'pointer',
+                          padding: '0',
+                          width: 'clamp(35px, 4vw, 50px)',
+                          height: 'clamp(35px, 4vw, 50px)'
+                      }}
+                  >
+                      <img
+                          src={shuffleIcon}
+                          alt="Shuffle"
+                          style={{
+                              width: '100%',
+                              height: '100%',
+                              opacity: 0.8,
+                              filter: shuffle ? 'none' : 'grayscale(100%) brightness(1.4)',
+                              transition: 'opacity 0.2s ease'
+                          }}
+                      />
+                  </button>
 
-              <button
-                onClick={() => nextTrack()}
-                style={{
-                  background: 'transparent',
-                  border: 'none',
-                  cursor: 'pointer',
-                  padding: '0',
-                  width: 'clamp(35px, 4vw, 50px)',
-                  height: 'clamp(35px, 4vw, 50px)'
-                }}
-              >
-                <img
-                  src={nextIcon}
-                  alt="Next"
-                  style={{
-                    width: '100%',
-                    height: '100%',
-                    opacity: 0.8,
-                    transition: 'opacity 0.2s ease'
-                  }}
-                />
-              </button>
-            </div>
+                  {/* Center-aligned Playback Controls */}
+                  <div
+                      style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '2vw'
+                      }}
+                  >
+                      <button
+                          onClick={() => prevTrack()}
+                          style={{
+                              background: 'transparent',
+                              border: 'none',
+                              cursor: 'pointer',
+                              padding: '0',
+                              width: 'clamp(35px, 4vw, 50px)',
+                              height: 'clamp(35px, 4vw, 50px)'
+                          }}
+                      >
+                          <img
+                              src={prevIcon}
+                              alt="Previous"
+                              style={{
+                                  width: '100%',
+                                  height: '100%',
+                                  opacity: 0.8,
+                                  transition: 'opacity 0.2s ease'
+                              }}
+                          />
+                      </button>
+
+                      <button
+                          onClick={() => togglePlay()}
+                          style={{
+                              background: 'transparent',
+                              border: 'none',
+                              cursor: 'pointer',
+                              padding: '0',
+                              width: 'clamp(45px, 5vw, 70px)',
+                              height: 'clamp(45px, 5vw, 70px)'
+                          }}
+                      >
+                          <img
+                              src={paused ? playIcon : pauseIcon}
+                              alt={paused ? "Play" : "Pause"}
+                              style={{
+                                  width: '100%',
+                                  height: '100%',
+                                  opacity: 0.8,
+                                  transition: 'opacity 0.2s ease'
+                              }}
+                          />
+                      </button>
+
+                      <button
+                          onClick={() => nextTrack()}
+                          style={{
+                              background: 'transparent',
+                              border: 'none',
+                              cursor: 'pointer',
+                              padding: '0',
+                              width: 'clamp(35px, 4vw, 50px)',
+                              height: 'clamp(35px, 4vw, 50px)'
+                          }}
+                      >
+                          <img
+                              src={nextIcon}
+                              alt="Next"
+                              style={{
+                                  width: '100%',
+                                  height: '100%',
+                                  opacity: 0.8,
+                                  transition: 'opacity 0.2s ease'
+                              }}
+                          />
+                      </button>
+                  </div>
+
+                  {/* Right Spacer (optional, use if you want symmetry) */}
+                  <div style={{ width: 'clamp(35px, 4vw, 50px)' }}></div>
+              </div>
           </div>
 
           <div style={{

--- a/jukeos/src/components/Home.js
+++ b/jukeos/src/components/Home.js
@@ -11,6 +11,7 @@ import ColorThief from "color-thief-browser";
 import nextIcon from "../assets/skip-forward-icon.svg"
 import prevIcon from "../assets/skip-backward-icon.svg"
 import shuffleIcon from "../assets/shuffle-icon.svg";
+import loopIcon from "../assets/loop-icon.svg";
 
 //Move location possibly in the future
 export function useColorThief(imageSrc) {
@@ -52,7 +53,9 @@ const Home = () => {
     progress: 0,
     duration: 1
   });
+
   const [shuffle, setShuffle] = useState(false);
+  const [loop, setLoop] = useState(false)
 
   const formatTime = (seconds) => {
     const minutes = Math.floor(seconds / 60);
@@ -84,13 +87,33 @@ const Home = () => {
     }
   };
 
-
     const toggleShuffle = useCallback(() => {
-        setShuffle(!shuffle);
-        console.log("Shuffle toggled: " + shuffle);
-        performPut("https://api.spotify.com/v1/me/player/shuffle", {shuffle}, null,
-            accessToken, invalidateAccess); //There is no response
-    }, [shuffle]);
+        const newShuffle = !shuffle;
+        setShuffle(newShuffle);
+        performPut(
+            "https://api.spotify.com/v1/me/player/shuffle",
+            { state: newShuffle },
+            null,
+            accessToken,
+            invalidateAccess
+        );
+    }, [shuffle, accessToken, invalidateAccess]);
+
+
+    const toggleLoop = useCallback(() => {
+        const newLoop = !loop;
+        setLoop(newLoop);
+        const loopString = newLoop ? "track" : "off";
+        performPut(
+            "https://api.spotify.com/v1/me/player/repeat",
+            { state: loopString },
+            null,
+            accessToken,
+            invalidateAccess
+        );
+    }, [loop, accessToken, invalidateAccess]);
+
+
   useEffect(() => {
     if (!accessToken) return;
 
@@ -261,7 +284,7 @@ const Home = () => {
                   style={{
                       display: 'flex',
                       alignItems: 'center',
-                      justifyContent: 'space-between', // Space out shuffle vs rest
+                      justifyContent: 'space-between',
                       marginTop: 'clamp(2vh, 3vh, 4vh)',
                       marginBottom: 'clamp(4vh, 6vh, 10vh)',
                       maxHeight: '80px',
@@ -371,38 +394,60 @@ const Home = () => {
                       </button>
                   </div>
 
-                  {/* Right Spacer (optional, use if you want symmetry) */}
-                  <div style={{ width: 'clamp(35px, 4vw, 50px)' }}></div>
+                  <button
+                      onClick={toggleLoop}
+                      style={{
+                          background: 'transparent',
+                          border: 'none',
+                          cursor: 'pointer',
+                          padding: '0',
+                          width: 'clamp(35px, 4vw, 50px)',
+                          height: 'clamp(35px, 4vw, 50px)',
+                      }}
+                  >
+                      <img
+                          src={loopIcon}
+                          alt="Loop"
+                          style={{
+                              width: '100%',
+                              height: '100%',
+                              opacity: 0.8,
+                              filter: loop ? 'none' : 'grayscale(100%) brightness(1.4)',
+                              transition: 'opacity 0.2s ease',
+                          }}
+                      />
+                  </button>
+
               </div>
           </div>
 
-          <div style={{
-            position: 'relative',
-            width: 'clamp(180px, 38%, 420px)',
-            aspectRatio: '1/1',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            margin: '0 auto',
-            flex: '0 1 auto',
-            zIndex: '1'
-          }}>
-            <AnimatedBlob
-              colors={useColorThief(track?.album?.images?.[0]?.url || defaultAlbumArt)}
-              style={{
-                width: '100%',
-                height: '100%',
-                maxWidth: '100%',
-                maxHeight: '100%',
-                zIndex: '-1'
-              }}
-              static={false}
-            />
-            <img
-              src={track?.album?.images?.[0]?.url || defaultAlbumArt}
-              alt="Album Art"
-              style={{
-                position: 'absolute',
+            <div style={{
+                position: 'relative',
+                width: 'clamp(180px, 38%, 420px)',
+                aspectRatio: '1/1',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                margin: '0 auto',
+                flex: '0 1 auto',
+                zIndex: '1'
+            }}>
+                <AnimatedBlob
+                    colors={useColorThief(track?.album?.images?.[0]?.url || defaultAlbumArt)}
+                    style={{
+                        width: '100%',
+                        height: '100%',
+                        maxWidth: '100%',
+                        maxHeight: '100%',
+                        zIndex: '-1'
+                    }}
+                    static={false}
+                />
+                <img
+                    src={track?.album?.images?.[0]?.url || defaultAlbumArt}
+                    alt="Album Art"
+                    style={{
+                        position: 'absolute',
                 width: '90%',
                 height: '90%',
                 objectFit: 'cover',


### PR DESCRIPTION
Adds shuffle and loop buttons and their associated logic. Currently we display the inactive button as a gray scaled version of itself. This is a temporary and needs to be improved upon in the future. We also are ignoring the loop context feature of looping and this only accounts for looping tracks.