### PR TITLE
Revamped, Curved Library Layout, Better Player Initialization, and Clean Animations

### DIFF
--- a/jukeos/src/components/Home.js
+++ b/jukeos/src/components/Home.js
@@ -10,6 +10,7 @@ import pauseIcon from '../assets/pause-icon.svg';
 import ColorThief from "color-thief-browser";
 import nextIcon from "../assets/skip-forward-icon.svg"
 import prevIcon from "../assets/skip-backward-icon.svg"
+import { motion, AnimatePresence } from 'framer-motion';
 
 //Move location possibly in the future
 export function useColorThief(imageSrc) {
@@ -244,32 +245,50 @@ const Home = () => {
             paddingLeft: 'clamp(20px, 4vw, 60px)',
             flex: '1 1 auto'
           }}>
-            <h1 style={{
-              fontFamily: 'Loubag, sans-serif',
-              fontSize: 'clamp(2.2rem, 4vw, 4rem)',
-              margin: '0',
-              textAlign: 'left',
-              color: '#ECE0C4',
-              textShadow: `
-                2px 2px 0 rgba(255,0,0,0.2),
-                -2px -2px 0 rgba(0,0,255,0.2),
-                1px -1px 0 rgba(255,0,255,0.2)
-              `,
-              animation: 'textGlitch 3s infinite'
-            }}>
-              {track?.name || "Unknown"}
-            </h1>
+            <AnimatePresence mode="wait">
+              <motion.h1
+                key={track?.name || "Unknown"}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.5, ease: "easeOut" }}
+                style={{
+                  fontFamily: 'Loubag, sans-serif',
+                  fontSize: 'clamp(2.2rem, 4vw, 4rem)',
+                  margin: '0',
+                  textAlign: 'left',
+                  color: '#ECE0C4',
+                  textShadow: `
+                    2px 2px 0 rgba(255,0,0,0.2),
+                    -2px -2px 0 rgba(0,0,255,0.2),
+                    1px -1px 0 rgba(255,0,255,0.2)
+                  `,
+                  animation: 'textGlitch 3s infinite'
+                }}
+              >
+                {track?.name || "Unknown"}
+              </motion.h1>
+            </AnimatePresence>
 
-            <h2 style={{
-              fontFamily: 'Notable, sans-serif',
-              fontSize: 'clamp(1.2rem, 2vw, 1.6rem)',
-              margin: '0',
-              opacity: 0.9,
-              letterSpacing: '1px',
-              color: 'white'
-            }}>
-              {track?.artists?.map(artist => artist.name)?.join(", ") || "Unknown"}
-            </h2>
+            <AnimatePresence mode="wait">
+              <motion.h2
+                key={track?.artists?.map(artist => artist.name)?.join(", ") || "Unknown"}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.5, ease: "easeOut", delay: 0.1 }}
+                style={{
+                  fontFamily: 'Notable, sans-serif',
+                  fontSize: 'clamp(1.2rem, 2vw, 1.6rem)',
+                  margin: '0',
+                  opacity: 0.9,
+                  letterSpacing: '1px',
+                  color: 'white'
+                }}
+              >
+                {track?.artists?.map(artist => artist.name)?.join(", ") || "Unknown"}
+              </motion.h2>
+            </AnimatePresence>
 
             <div style={{
               display: 'flex',
@@ -278,7 +297,8 @@ const Home = () => {
               fontSize: 'clamp(0.7rem, 1vw, 0.9rem)',
               color: '#ECE0C4',
               opacity: 0.8,
-              marginTop: '0.5vh'
+              marginTop: '0.5vh',
+              fontFamily: 'Loubag, sans-serif'
             }}>
               <span>{formatTime(currentTrack.progress)}</span>
               <span>{formatTime(currentTrack.duration)}</span>
@@ -288,25 +308,13 @@ const Home = () => {
               width: '100%',
               marginTop: '1vh'
             }}>
-              <div
-                style={{
-                  width: '100%',
-                  height: '4px',
-                  backgroundColor: 'rgba(236, 224, 196, 0.2)',
-                  borderRadius: '2px',
-                  position: 'relative',
-                  cursor: 'pointer'
-                }}
-                onClick={handleProgressClick}
-              >
-                <div style={{
-                  width: `${(currentTrack.progress / currentTrack.duration) * 100}%`,
-                  height: '100%',
-                  backgroundColor: '#ECE0C4',
-                  borderRadius: '2px',
-                  position: 'absolute',
-                  transition: 'width 0.1s linear'
-                }}/>
+              <div className="progress-bar" onClick={handleProgressClick}>
+                <div 
+                  className="progress-indicator"
+                  style={{
+                    width: `${(currentTrack.progress / currentTrack.duration) * 100}%`
+                  }}
+                />
               </div>
             </div>
 
@@ -392,41 +400,67 @@ const Home = () => {
             </div>
           </div>
 
-          <div style={{
-            position: 'relative',
-            width: 'clamp(180px, 38%, 420px)',
-            aspectRatio: '1/1',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            margin: '0 auto',
-            flex: '0 1 auto',
-            zIndex: '1'
-          }}>
-            <AnimatedBlob
-              colors={useColorThief(track?.album?.images?.[0]?.url || defaultAlbumArt)}
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={track?.album?.images?.[0]?.url || "default"}
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{ duration: 0.5, ease: "easeOut" }}
               style={{
-                width: '100%',
-                height: '100%',
-                maxWidth: '100%',
-                maxHeight: '100%',
-                zIndex: '-1'
+                position: 'relative',
+                width: 'clamp(180px, 38%, 420px)',
+                aspectRatio: '1/1',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                margin: '0 auto',
+                flex: '0 1 auto',
+                zIndex: '1'
               }}
-              static={false}
-            />
-            <img
-              src={track?.album?.images?.[0]?.url || defaultAlbumArt}
-              alt="Album Art"
-              style={{
-                position: 'absolute',
-                width: '90%',
-                height: '90%',
-                objectFit: 'cover',
-                borderRadius: '8px',
-                boxShadow: '0 8px 24px rgba(0,0,0,0.4)'
-              }}
-            />
-          </div>
+            >
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={`blob-${track?.album?.images?.[0]?.url || "default"}`}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.6, ease: "easeOut" }}
+                  style={{ position: 'absolute', width: '100%', height: '100%', zIndex: -1 }}
+                >
+                  <AnimatedBlob
+                    colors={useColorThief(track?.album?.images?.[0]?.url || defaultAlbumArt)}
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      maxWidth: '100%',
+                      maxHeight: '100%',
+                      zIndex: '-1'
+                    }}
+                    static={false}
+                  />
+                </motion.div>
+              </AnimatePresence>
+
+              <motion.img
+                key={`img-${track?.album?.images?.[0]?.url || "default"}`}
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.9 }}
+                transition={{ duration: 0.5, ease: "easeOut" }}
+                src={track?.album?.images?.[0]?.url || defaultAlbumArt}
+                alt="Album Art"
+                style={{
+                  position: 'absolute',
+                  width: '90%',
+                  height: '90%',
+                  objectFit: 'cover',
+                  borderRadius: '8px',
+                  boxShadow: '0 8px 24px rgba(0,0,0,0.4)'
+                }}
+              />
+            </motion.div>
+          </AnimatePresence>
         </div>
         
         <div style={{
@@ -506,6 +540,57 @@ const Home = () => {
           </div>
         </div>
       </div>
+
+      <style>
+        {`
+          @keyframes progressShimmer {
+            0% {
+              background-position: -200% center;
+            }
+            100% {
+              background-position: 200% center;
+            }
+          }
+
+          .progress-bar {
+            position: relative;
+            width: 100%;
+            height: 8px;
+            background-color: rgba(236, 224, 196, 0.2);
+            border-radius: 4px;
+            cursor: pointer;
+            overflow: hidden;
+          }
+
+          .progress-indicator {
+            position: absolute;
+            height: 100%;
+            background-color: #ECE0C4;
+            border-radius: 4px;
+            transition: width 0.1s linear;
+            overflow: hidden;
+          }
+
+          .progress-indicator::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            background: linear-gradient(
+              90deg, 
+              transparent,
+              rgba(255, 255, 255, 0.2),
+              transparent
+            );
+            background-size: 200% 100%;
+            animation: progressShimmer 2s infinite;
+            pointer-events: none;
+            z-index: 1;
+          }
+        `}
+      </style>
     </div>
   );
 };

--- a/jukeos/src/components/Library.js
+++ b/jukeos/src/components/Library.js
@@ -7,289 +7,656 @@ import defaultAlbumArt from '../assets/default-art-placeholder.svg';
 import AnimatedBlob from './AnimatedBlob';
 import { useColorThief } from './Home';
 
-// Constants for album layout
-const ITEM_WIDTH = 150; // Width of album art
-const ITEM_HEIGHT = 150; // Height of album art
-const VIEW_HEIGHT = 350; // Height of the viewing area
-const HORIZONTAL_SPREAD = 0.85; // How much horizontal space to use (0-1)
+// --- Responsive Constants using clamp() ---
+// Sizes based on viewport width (vw) and height (vh)
+const RESPONSIVE_ITEM_SIZE = 'clamp(100px, 10vw, 150px)'; // Item size between 100px and 150px
+const RESPONSIVE_VIEW_HEIGHT = 'clamp(280px, 30vh, 400px)'; // View height between 280px and 400px
+const RESPONSIVE_SPACING = 'clamp(130px, 12vw, 180px)'; // Spacing between 130px and 180px
+const RESPONSIVE_ARC_HEIGHT = 'clamp(30px, 5vh, 60px)'; // Arc height between 30px and 60px
+const RESPONSIVE_TITLE_SIZE = 'clamp(1.6rem, 3vw, 2.5rem)';
+const RESPONSIVE_TITLE_SPACING = 'clamp(2px, 0.5vw, 4px)';
+const TITLE_CURVE = 10; // Keep title curve subtle
+
+// Visibility based on width - more items on wider screens
+const MIN_VISIBLE_ITEMS = 7;
+const MAX_VISIBLE_ITEMS = 11;
 
 const ScrollWheel = ({ items, playUri }) => {
-  const [position, setPosition] = useState(0); // Position in the album list (0-1)
+  const [centerIndex, setCenterIndex] = useState(0);
+  const [containerWidth, setContainerWidth] = useState(window.innerWidth);
+  const containerRef = useRef(null);
   const [isDragging, setIsDragging] = useState(false);
   const [startX, setStartX] = useState(0);
-  const [startPosition, setStartPosition] = useState(0);
-  const containerRef = useRef(null);
-  
-  // Handle mouse down
+  const [startCenterIndex, setStartCenterIndex] = useState(0);
+  const [isSnapping, setIsSnapping] = useState(false);
+  const velocityRef = useRef(0);
+  const lastScrollTime = useRef(Date.now());
+  const lastScrollValue = useRef(0);
+  const animationFrameRef = useRef(null);
+
+  const SNAP_THRESHOLD = 0.3;
+  const SCROLL_SENSITIVITY = 0.0015;
+  const MIN_VELOCITY_TO_KEEP_SCROLLING = 0.05;
+  const VELOCITY_DECAY = 0.85;
+
+  // Add playing state tracking
+  const [playingUri, setPlayingUri] = useState(null);
+  const [pulsing, setPulsing] = useState(null);
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+
+  // Smooth scrolling animation
+  const animateScroll = () => {
+    if (Math.abs(velocityRef.current) < MIN_VELOCITY_TO_KEEP_SCROLLING) {
+      velocityRef.current = 0;
+      snapToNearest(centerIndex);
+      return;
+    }
+
+    const newIndex = centerIndex + velocityRef.current;
+    
+    // If we hit the bounds, stop scrolling
+    if (newIndex <= 0 || newIndex >= items.length - 1) {
+      velocityRef.current = 0;
+      snapToNearest(centerIndex);
+      return;
+    }
+
+    setCenterIndex(newIndex);
+    velocityRef.current *= VELOCITY_DECAY;
+    animationFrameRef.current = requestAnimationFrame(animateScroll);
+  };
+
+  // Handle wheel/trackpad events
+  const handleWheel = (e) => {
+    e.preventDefault();
+
+    // Calculate time since last scroll
+    const now = Date.now();
+    const timeDelta = now - lastScrollTime.current;
+    lastScrollTime.current = now;
+
+    // Use the larger of deltaX or deltaY, prioritizing horizontal
+    const scrollValue = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+    
+    // Calculate velocity based on scroll value and time delta
+    if (timeDelta > 0) {
+      const instantVelocity = (scrollValue - lastScrollValue.current) / timeDelta;
+      velocityRef.current = instantVelocity * SCROLL_SENSITIVITY;
+    }
+    
+    lastScrollValue.current = scrollValue;
+
+    // Cancel any existing animation
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+
+    // Start new animation
+    animationFrameRef.current = requestAnimationFrame(animateScroll);
+  };
+
+  // Clean up animation frame on unmount
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, []);
+
+  // Snap to nearest index function
+  const snapToNearest = (currentIndex) => {
+    const nearestIndex = Math.round(currentIndex);
+    const distanceFromNearest = Math.abs(currentIndex - nearestIndex);
+    
+    if (distanceFromNearest < SNAP_THRESHOLD) {
+      setIsSnapping(true);
+      setCenterIndex(nearestIndex);
+      velocityRef.current = 0;
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+      setTimeout(() => setIsSnapping(false), 300);
+    }
+  };
+
+  // Handle click on item with single pulse effect
+  const handleItemClick = (index) => {
+    setIsSnapping(true);
+    setCenterIndex(index);
+    velocityRef.current = 0;
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+    
+    // Set playing URI and trigger single pulse
+    const uri = items[index].uri;
+    setPlayingUri(uri);
+    setPulsing(uri);
+    setTimeout(() => {
+      setPulsing(null);
+      setIsSnapping(false);
+      playUri(uri);
+    }, 300);
+  };
+
+  // --- Responsive Calculations based on containerWidth ---
+  const responsiveValues = useMemo(() => {
+    const width = containerWidth;
+    const baseWidth = 1000; // Reference width for scaling calculations
+    // Calculate a ratio based on current width compared to base, clamped for stability
+    const widthRatio = Math.max(0.8, Math.min(1.3, width / baseWidth)); 
+
+    // Calculate how many items should be visible
+    const visibleItemsCount = Math.round(
+      MIN_VISIBLE_ITEMS + (MAX_VISIBLE_ITEMS - MIN_VISIBLE_ITEMS) * (widthRatio - 0.8) / 0.5 // Scale between min/max based on ratio
+    );
+
+    // Parse clamped values (removing units like 'px', 'rem') for calculations
+    // This is a simplified way, assumes 'px' or 'rem' units primarily.
+    // A more robust solution might use CSS variables or a dedicated parsing library.
+    const parseClamp = (clampStr) => {
+        // Basic parsing - assumes format "clamp(min, preferred, max)"
+        const values = clampStr.match(/\((.*?), (.*?), (.*?)\)/);
+        if (!values) return 100; // Default fallback
+        // We'll use the preferred value (vw/vh based) for dynamic calculation reference
+        // A more complex logic could interpolate between min/max based on widthRatio
+        const preferredValue = parseFloat(values[2]); 
+        const unit = values[2].replace(/[\d.-]/g, '');
+        // Approximate conversion for calculations (highly simplified)
+        if (unit === 'vw') return preferredValue * width / 100;
+        if (unit === 'vh') return preferredValue * window.innerHeight / 100;
+        if (unit === 'rem') return preferredValue * 16; // Assuming 1rem = 16px
+        return preferredValue; // Assume px
+    };
+
+    const calculatedSpacing = parseClamp(RESPONSIVE_SPACING) * Math.max(0.9, widthRatio); // Slightly increase spacing on wider screens
+    const calculatedArcHeight = parseClamp(RESPONSIVE_ARC_HEIGHT) * Math.max(0.8, 1.2 - (widthRatio * 0.2)); // Decrease arc height slightly on wider
+    const calculatedItemSize = parseClamp(RESPONSIVE_ITEM_SIZE);
+
+    return {
+        count: Math.max(MIN_VISIBLE_ITEMS, visibleItemsCount), // Ensure at least min are shown
+        arcHeight: calculatedArcHeight,
+        spacing: calculatedSpacing,
+        itemSize: calculatedItemSize
+    };
+  }, [containerWidth]);
+
+  // Add resize listener
+  useEffect(() => {
+    const handleResize = () => {
+      if (containerRef.current) {
+        setContainerWidth(containerRef.current.clientWidth);
+      } else {
+        // Fallback if ref not ready
+        setContainerWidth(window.innerWidth);
+      }
+    };
+    handleResize(); // Initial call
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   const handleMouseDown = (e) => {
+    if (isSnapping) return;
     setIsDragging(true);
     setStartX(e.clientX);
-    setStartPosition(position);
-    if (containerRef.current) {
-      containerRef.current.style.cursor = 'grabbing';
+    setStartCenterIndex(centerIndex);
+    velocityRef.current = 0;
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
     }
   };
-  
-  // Handle mouse up
-  const handleMouseUp = () => {
-    if (!isDragging) return;
-    setIsDragging(false);
-    
-    if (containerRef.current) {
-      containerRef.current.style.cursor = 'grab';
-    }
-    
-    // Snap to nearest item
-    if (items.length > 1) {
-      const itemFraction = 1 / (items.length - 1);
-      const nearestItemPosition = Math.round(position / itemFraction) * itemFraction;
-      setPosition(Math.max(0, Math.min(1, nearestItemPosition)));
-    }
-  };
-  
-  // Handle mouse move
+
   const handleMouseMove = (e) => {
-    if (!isDragging) return;
-    e.preventDefault();
+    if (!isDragging || isSnapping) return;
     
-    const containerWidth = containerRef.current?.clientWidth || 1000;
-    const deltaX = (startX - e.clientX) / containerWidth;
-    const newPosition = startPosition + deltaX * 1.5; // Adjust sensitivity
+    const deltaX = e.clientX - startX;
+    const itemsPerScreen = responsiveValues.count;
+    const totalItems = items.length;
+    const dragSensitivity = 0.5;
     
-    // Clamp position between 0 and 1
-    setPosition(Math.max(0, Math.min(1, newPosition)));
+    const newCenterIndex = startCenterIndex - (deltaX / (containerWidth / itemsPerScreen)) * dragSensitivity;
+    const boundedIndex = Math.max(0, Math.min(totalItems - 1, newCenterIndex));
+    setCenterIndex(boundedIndex);
+
+    // Check for snap while dragging
+    snapToNearest(boundedIndex);
   };
-  
-  // Get visible items (filtering to just what we need to render)
+
+  const handleMouseUp = () => {
+    if (isDragging) {
+      setIsDragging(false);
+      snapToNearest(centerIndex);
+    }
+  };
+
+  useEffect(() => {
+    if (isDragging) {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+      return () => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+      };
+    }
+  }, [isDragging, startX, startCenterIndex]);
+
+  // --- Visibility and Styling Logic ---
   const getVisibleItems = () => {
     if (!items || items.length === 0) return [];
-    
-    // For simplicity, we'll render all items but adjust their visibility/position based on scroll position
-    return items.map((item, index) => {
-      // Calculate where this item should be in the scroll position (0-1)
-      const itemPosition = items.length > 1 ? index / (items.length - 1) : 0.5;
-      
-      // Calculate how far this item is from the current view position
-      const distanceFromCenter = Math.abs(itemPosition - position);
-      
-      // Calculate visibility threshold - items too far from view position aren't rendered
-      const isVisible = distanceFromCenter < 0.4; // Only show items within 40% of the view position
-      
-      // Calculate a factor (0-1) for how centered this item is (used for scaling, opacity)
-      const centeredness = Math.max(0, 1 - distanceFromCenter * 2.5);
-      
-      return {
-        item,
-        index,
-        itemPosition,
-        distanceFromCenter,
-        centeredness,
-        isVisible
-      };
-    }).filter(item => item.isVisible);
+    const boundedCenterIndex = Math.max(0, Math.min(items.length - 1, centerIndex));
+    const halfVisible = Math.floor(responsiveValues.count / 2);
+    const minIndex = Math.max(0, Math.floor(boundedCenterIndex - halfVisible));
+    const maxIndex = Math.min(items.length - 1, Math.ceil(boundedCenterIndex + halfVisible));
+    const results = [];
+    for (let i = minIndex; i <= maxIndex; i++) {
+      const distanceFromCenter = i - boundedCenterIndex;
+      const centeredness = Math.max(0, 1 - (Math.abs(distanceFromCenter) / halfVisible));
+      results.push({
+        item: items[i],
+        index: i,
+        distanceFromCenter: distanceFromCenter,
+        centeredness: centeredness,
+        isVisible: true
+      });
+    }
+    return results;
   };
-  
-  // Calculate an item's position and style based on its place in the scroll
-  const getItemStyle = (visibleItem) => {
-    const { itemPosition, centeredness } = visibleItem;
-    const containerWidth = containerRef.current?.clientWidth || 1000;
-    
-    // Basic screen positioning - horizontal spread based on item position
-    // Note we spread items across up to HORIZONTAL_SPREAD (85%) of the container width
-    const relativePosition = itemPosition - position; // -1 to 1, with 0 being centered
-    
-    // Distribute albums horizontally
-    const horizontalSpread = containerWidth * HORIZONTAL_SPREAD;
-    const x = relativePosition * horizontalSpread;
-    
-    // Calculate rotation - albums should be tilted based on position
-    // Negative relativePosition = left side = negative rotation (tilting right)
-    // Positive relativePosition = right side = positive rotation (tilting left)
-    // Center position = no rotation
-    const rotationDegrees = relativePosition * 25; // Maximum ±25° rotation
-    
-    // Calculate scale - center items are bigger
-    const scale = 0.75 + centeredness * 0.45; // Scale from 0.75 to 1.2
-    
-    // Calculate opacity - center items are more opaque
-    const opacity = 0.3 + centeredness * 0.7; // Opacity from 0.3 to 1.0
-    
-    // Calculate z-index - center items are on top
-    const zIndex = Math.round(50 + centeredness * 50); // z-index from 50 to 100
-    
-    // Calculate vertical position - creating slight vertical arc
-    // Items further from center drop down slightly
-    const distanceFromCenterAbs = Math.abs(relativePosition);
-    const y = distanceFromCenterAbs * distanceFromCenterAbs * 120; // Parabolic drop
+
+  const getItemStyle = (itemData) => {
+    const { distanceFromCenter, centeredness } = itemData;
+    const x = distanceFromCenter * responsiveValues.spacing;
+    const arcDivisor = Math.max(1.5, 2.5 - (containerWidth / 1000));
+    const y = Math.pow(distanceFromCenter / arcDivisor, 2) * responsiveValues.arcHeight;
+    const rotationMultiplier = Math.max(4, 10 - (containerWidth / 200));
+    const rotationDegrees = distanceFromCenter * rotationMultiplier;
+    const opacity = 0.4 + centeredness * 0.6;
+    const zIndex = Math.round(100 - Math.abs(distanceFromCenter) * 10);
     
     return {
-      transform: `translate(${x}px, ${y}px) rotate(${rotationDegrees}deg) scale(${scale})`,
+      transform: `translate(${x}px, ${y}px) rotate(${rotationDegrees}deg)`,
       opacity,
-      zIndex
+      zIndex,
+      transition: isSnapping ? 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)' : 
+                 isDragging ? 'none' : 
+                 'all 0.25s ease-out'
     };
   };
-  
-  // Get the central item for potentially highlighting
-  const getCenterIndex = () => {
-    if (items.length === 0) return -1;
-    return Math.round(position * (items.length - 1));
-  };
-  
-  const visibleItems = getVisibleItems();
-  const centerIndex = getCenterIndex();
-  
+
+  const displayedItems = useMemo(() => getVisibleItems(), [centerIndex, items, responsiveValues.count]);
+  const isCenterExact = Math.abs(centerIndex - Math.round(centerIndex)) < 0.01;
+
+  // --- Render Logic ---
   return (
-    <div
-      ref={containerRef}
-      className="albums-container"
+    <>
+      <style>
+        {`
+          @keyframes shimmer {
+            0% {
+              background-position: -200% center;
+            }
+            100% {
+              background-position: 200% center;
+            }
+          }
+
+          @keyframes singlePulse {
+            0% {
+              transform: scale(1);
+              box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.7);
+            }
+            50% {
+              transform: scale(1.05);
+              box-shadow: 0 0 0 10px rgba(255, 255, 255, 0);
+            }
+            100% {
+              transform: scale(1);
+              box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+            }
+          }
+
+          .album-item {
+            transition: all 0.2s ease !important;
+          }
+
+          .album-item.pulsing {
+            animation: singlePulse 0.3s ease-out forwards;
+          }
+
+          .album-item.playing::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            background: linear-gradient(
+              90deg, 
+              transparent, 
+              rgba(255, 255, 255, 0.2), 
+              transparent
+            );
+            background-size: 200% 100%;
+            border-radius: clamp(4px, 0.8vw, 8px);
+            animation: shimmer 2s infinite;
+            pointer-events: none;
+          }
+
+          .button-underglow {
+            position: relative;
+          }
+
+          .button-underglow::after {
+            content: '';
+            position: absolute;
+            top: -2px;
+            left: -2px;
+            right: -2px;
+            bottom: -2px;
+            background: inherit;
+            filter: blur(8px);
+            opacity: 0;
+            z-index: -1;
+            transition: opacity 0.2s ease;
+            border-radius: inherit;
+          }
+
+          .button-underglow:hover::after {
+            opacity: 0.6;
+          }
+        `}
+      </style>
+
+      <div
+        ref={containerRef}
+        className="curved-albums-container"
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: 'auto',
+          overflow: 'visible',
+          zIndex: 1000,
+          cursor: isDragging ? 'grabbing' : 'grab',
+        }}
+        onMouseDown={handleMouseDown}
+        onWheel={handleWheel}
+      >
+        {/* Left arrow */}
+        <div
+          style={{
+            position: 'absolute',
+            left: '10%',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            zIndex: 1001,
+            cursor: 'pointer',
+            opacity: 0.3,
+            transition: 'opacity 0.2s ease',
+            pointerEvents: 'auto',
+          }}
+          onMouseEnter={(e) => e.currentTarget.style.opacity = '0.6'}
+          onMouseLeave={(e) => e.currentTarget.style.opacity = '0.3'}
+          onClick={() => {
+            if (centerIndex > 0) {
+              setCenterIndex(centerIndex - 1);
+            }
+          }}
+        >
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M15 18L9 12L15 6" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </div>
+
+        {/* Right arrow */}
+        <div
+          style={{
+            position: 'absolute',
+            right: '10%',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            zIndex: 1001,
+            cursor: 'pointer',
+            opacity: 0.3,
+            transition: 'opacity 0.2s ease',
+            pointerEvents: 'auto',
+          }}
+          onMouseEnter={(e) => e.currentTarget.style.opacity = '0.6'}
+          onMouseLeave={(e) => e.currentTarget.style.opacity = '0.3'}
+          onClick={() => {
+            if (centerIndex < items.length - 1) {
+              setCenterIndex(centerIndex + 1);
+            }
+          }}
+        >
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M9 18L15 12L9 6" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </div>
+
+        {displayedItems.map((itemData) => {
+          const { item, index } = itemData;
+          const style = getItemStyle(itemData);
+          const isCentered = Math.abs(index - centerIndex) < 0.1;
+          const isPlaying = item.uri === playingUri;
+          const isPulsing = item.uri === pulsing;
+          const isHovered = index === hoveredIndex;
+          
+          const itemSizeValue = `calc(${RESPONSIVE_ITEM_SIZE})`;
+          const halfItemSizeValue = `calc(${RESPONSIVE_ITEM_SIZE} / -2)`;
+
+          // Combine all transforms into one
+          const baseTransform = style.transform;
+          const scaleTransform = (isCentered || isHovered) ? ' scale(1.1)' : '';
+          const combinedTransform = baseTransform + scaleTransform;
+
+          return (
+            <div
+              key={item.uri || index}
+              className={`album-item button-underglow ${isPlaying ? 'playing' : ''} ${isPulsing ? 'pulsing' : ''}`}
+              style={{
+                position: 'absolute',
+                width: itemSizeValue,
+                height: itemSizeValue,
+                top: '50%',
+                left: '50%',
+                marginLeft: halfItemSizeValue,
+                marginTop: halfItemSizeValue,
+                transform: combinedTransform,
+                opacity: style.opacity,
+                zIndex: isHovered ? 1000 : style.zIndex,
+                transition: style.transition,
+                cursor: 'pointer',
+                boxShadow: isPlaying ? 
+                  '0 0 20px rgba(255,255,255,0.3), 0 0 40px rgba(255,255,255,0.1)' : 
+                  '0 clamp(4px, 1vh, 8px) clamp(10px, 2vh, 20px) rgba(0,0,0,0.3)',
+              }}
+              onClick={() => handleItemClick(index)}
+              onMouseEnter={() => setHoveredIndex(index)}
+              onMouseLeave={() => setHoveredIndex(null)}
+            >
+              <img
+                src={item.imageUrl || defaultAlbumArt}
+                alt={item.title}
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'cover',
+                  borderRadius: 'clamp(4px, 0.8vw, 8px)',
+                  userSelect: 'none',
+                  pointerEvents: 'none',
+                  transition: style.transition,
+                }}
+                onDragStart={(e) => e.preventDefault()}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+};
+
+// --- LibrarySection Component ---
+const LibrarySection = ({ title, items, playUri }) => {
+  const { playingUri } = useContext(PlayerContext);
+  const [selectedIndex, setSelectedIndex] = useState(null);
+  const [pulsing, setPulsing] = useState(false);
+
+  // Calculate SVG dimensions based on title length
+  const svgWidth = 1000;  // Fixed width for consistent arc
+  const svgHeight = 100;  // Height for subtle arc
+  const radius = 1500;    // Large radius for subtle curve
+  
+  // Create the arc path
+  const startX = 0;
+  const startY = svgHeight;
+  const endX = svgWidth;
+  const endY = svgHeight;
+  const arcPath = `M ${startX},${startY} A ${radius},${radius} 0 0,1 ${endX},${endY}`;
+
+  const handleItemClick = (index, item) => {
+    setSelectedIndex(index);
+    setPulsing(true);
+    playUri(item.uri);
+  };
+
+  const getItemStyle = (index, item) => {
+    const isSelected = selectedIndex === index;
+    const isPlaying = item.uri === playingUri;
+    const distanceFromCenter = Math.abs(index - selectedIndex);
+    const scale = isSelected ? 1.1 : 1;
+    const zIndex = isSelected ? 2 : 1;
+    const transform = `scale(${scale}) translateY(${Math.pow(Math.abs(distanceFromCenter), 1.5) * 0.03}em) rotate(${distanceFromCenter * 0.8}deg)`;
+    
+    return {
+      transform,
+      zIndex,
+      animation: isPlaying ? 'pulse 2s infinite' : isSelected && pulsing ? 'pulse 2s' : 'none',
+      transition: 'transform 0.3s ease, z-index 0.3s ease',
+      cursor: 'pointer',
+      position: 'relative',
+      '&:hover': {
+        transform: `scale(1.05) translateY(${Math.pow(Math.abs(distanceFromCenter), 1.5) * 0.03}em) rotate(${distanceFromCenter * 0.8}deg)`,
+        zIndex: 2
+      }
+    };
+  };
+
+  // Reset pulsing state when selection changes
+  useEffect(() => {
+    if (selectedIndex !== null) {
+      const timer = setTimeout(() => {
+        setPulsing(false);
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [selectedIndex]);
+
+  // Check if any item is currently playing when component mounts
+  useEffect(() => {
+    if (playingUri) {
+      const playingIndex = items.findIndex(item => item.uri === playingUri);
+      if (playingIndex !== -1) {
+        setSelectedIndex(playingIndex);
+      }
+    }
+  }, [playingUri, items]);
+
+  return (
+    <div className="library-section"
       style={{
         position: 'relative',
         width: '100%',
-        height: `${VIEW_HEIGHT}px`,
-        overflow: 'hidden',
-        cursor: isDragging ? 'grabbing' : 'grab',
+        marginBottom: '25vh',
+        overflow: 'visible',
       }}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseUp}
-      onMouseMove={handleMouseMove}
-      onTouchStart={(e) => handleMouseDown({clientX: e.touches[0].clientX})}
-      onTouchEnd={handleMouseUp}
-      onTouchMove={(e) => handleMouseMove({clientX: e.touches[0].clientX, preventDefault: () => e.preventDefault()})}
     >
-      {visibleItems.map(visibleItem => {
-        const { item, index } = visibleItem;
-        const style = getItemStyle(visibleItem);
-        const isCentered = index === centerIndex;
-        
-        return (
-          <div
-            key={item.uri || index}
-            className="album-item"
-            style={{
-              position: 'absolute',
-              width: `${ITEM_WIDTH}px`,
-              height: `${ITEM_HEIGHT}px`,
-              top: '50%',
-              left: '50%',
-              marginLeft: `-${ITEM_WIDTH/2}px`,
-              marginTop: `-${ITEM_HEIGHT/2}px`,
-              transform: style.transform,
-              opacity: style.opacity,
-              zIndex: style.zIndex,
-              transition: isDragging ? 'none' : 'all 0.3s ease-out',
-            }}
-            onClick={() => {
-              if (isCentered) {
-                // Play if centered
-                playUri(item.uri);
-              } else {
-                // Otherwise scroll to this item
-                const targetPosition = items.length > 1 ? index / (items.length - 1) : 0;
-                setPosition(targetPosition);
-              }
-            }}
-          >
-            <img
-              src={item.imageUrl || defaultAlbumArt}
-              alt={item.title}
-              style={{
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-                borderRadius: '8px',
-                boxShadow: `0 ${4 + style.zIndex/25}px ${15}px rgba(0,0,0,${0.3 + (100-style.zIndex)/300})`,
-                userSelect: 'none',
-              }}
-              onDragStart={(e) => e.preventDefault()}
+      {/* Title positioned above the scroll wheel */}
+      <div className="section-title" 
+        style={{ 
+          position: 'relative',
+          zIndex: 15, 
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          marginBottom: '8vh',
+        }}
+      >
+        <svg
+          width="100%"
+          height={svgHeight}
+          viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+          style={{
+            overflow: 'visible',
+          }}
+        >
+          <defs>
+            <path
+              id={`titlePath-${title}`}
+              d={arcPath}
+              fill="none"
             />
-          </div>
-        );
-      })}
+          </defs>
+          <text
+            style={{
+              fontSize: RESPONSIVE_TITLE_SIZE,
+              fontFamily: 'Loubag, sans-serif',
+              fill: '#fcdba0',
+              filter: 'drop-shadow(0 0 1px rgba(255, 199, 100, 0.25)) drop-shadow(0 0 20px rgba(255, 203, 100, 0.2))',
+              letterSpacing: RESPONSIVE_TITLE_SPACING,
+            }}
+            dominantBaseline="middle"
+            textAnchor="middle"
+          >
+            <textPath
+              href={`#titlePath-${title}`}
+              startOffset="50%"
+              textAnchor="middle"
+            >
+              {title}
+            </textPath>
+          </text>
+        </svg>
+      </div>
+
+      <ScrollWheel items={items} playUri={playUri} />
     </div>
   );
 };
 
+// --- selectBestImage Function (Keep existing) ---
 export function selectBestImage(images) {
     const minWidth = 150, minHeight = 150;
-
     return images.reduce((previous, current) => {
         const validImage
             = current.width >= minWidth && current.height >= minHeight;
         const betterThanPrevious
             = !previous || (current.width < previous.width && current.height < previous.height);
-
         return (validImage && betterThanPrevious)
             ? current : previous;
     }, null) || images[0];
 }
 
-const LibrarySection = ({ title, items, playUri }) => {
-  // Ensure items is always an array
-  const validItems = Array.isArray(items) ? items : [];
-
-  return (
-    <div className="library-section" 
-      style={{ 
-        marginBottom: '120px', 
-        position: 'relative',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-      }}
-    >
-      {/* Radial glow effect */}
-      <div style={{
-        position: 'absolute',
-        width: '100%',
-        height: '100%',
-        background: 'radial-gradient(ellipse at center, rgba(255,199,100,0.15) 0%, rgba(255,140,0,0.05) 40%, rgba(0,0,0,0) 70%)',
-        pointerEvents: 'none',
-        zIndex: 1,
-      }} />
-      
-      <div className="section-title" 
-        style={{ 
-          marginBottom: '40px',
-          position: 'relative',
-          zIndex: 5,
-        }}
-      >
-        <h2 style={{
-          fontSize: 'clamp(2.5rem, 5vw, 3.5rem)',
-          fontFamily: 'Loubag, sans-serif',
-          color: '#FFC764',
-          textShadow: '0 0 20px rgba(255, 199, 100, 0.7)',
-          letterSpacing: '8px',
-          textAlign: 'center',
-          margin: 0,
-          textTransform: 'uppercase',
-        }}>
-          {title}
-        </h2>
-      </div>
-      
-      <ScrollWheel items={validItems} playUri={playUri} />
-    </div>
-  );
-};
-
-
+// --- LibraryTesting Component ---
 const LibraryTesting = () => {
   const { accessToken, invalidateAccess } = useContext(SpotifyAuthContext);
   const { track, playUri } = useContext(PlayerContext);
 
+  // State for library sections (Keep existing)
   const [ madeForYou, setMadeForYou ] = useState([]);
   const [ playlists, setPlaylists ] = useState([]);
   const [ podcasts, setPodcasts ] = useState([]);
   const [ albums, setAlbums ] = useState([]);
   const [ artists, setArtists ] = useState([]);
 
-  // Determine album art URL and get colors using the hook
   const albumArtUrl = track?.album?.images?.[0]?.url || defaultAlbumArt;
   const colors = useColorThief(albumArtUrl);
 
-  // Consider implementing pagination if needed
+  // sections definition (Keep existing)
   const sections = useMemo(() => [
     {
       title: "MADE FOR YOU",
@@ -313,18 +680,11 @@ const LibraryTesting = () => {
     }
   ], [madeForYou, playlists, podcasts, albums, artists]);
 
-  /*
-    This pulls the list of current user's top items. It gets the names and images of the albums from the response and put 
-    them into `setMadeForYou`. 
-
-    Relevant Documentation: https://developer.spotify.com/documentation/web-api/reference/get-users-top-artists-and-tracks
-  */
+  // Fetch functions (Keep existing)
   const fetchTopItems = (type) => {
     if (accessToken) {
       performFetch("https://api.spotify.com/v1/me/top/" + type, {}, accessToken, invalidateAccess)
         .then((response) => {
-          console.log("Successfully fetched top items:", response);
-
           if (response && response.items) {
             setMadeForYou(
               response.items
@@ -341,19 +701,10 @@ const LibraryTesting = () => {
         });
     }
   };
-
-  /*
-    This pulls the list of the playlists that are owned or followed by the current user. It gets the names and the images of 
-    the playlists from the response and put them into `setPlayLists`.
-
-    Relevant Documentation: https://developer.spotify.com/documentation/web-api/reference/get-a-list-of-current-users-playlists
-  */
   const fetchPlaylists = () => {
     if (accessToken) {
       performFetch("https://api.spotify.com/v1/me/playlists", {}, accessToken, invalidateAccess)
         .then((response) => {
-          console.log("Successfully fetched playlists:", response);
-
           if (response && response.items) {
             setPlaylists(
               response.items
@@ -370,22 +721,10 @@ const LibraryTesting = () => {
       });
     }
   };
-
-  /*
-    This pulls the list of the podcasts that are saved by the current user. It gets the names and the images 
-    of the podcasts from the response and put them into `setPodcasts`. 
-    
-    PLEASE NOTE: it is correct that this requests to pull the shows, but this is the actual way to obtain 
-    information of the current user's saved podcasts from Spotify.
-
-    Relevant Documentation: https://developer.spotify.com/documentation/web-api/reference/get-users-saved-shows
-  */
   const fetchPodcasts = () => {
     if (accessToken) {
       performFetch("https://api.spotify.com/v1/me/shows", {}, accessToken, invalidateAccess)
         .then((response) => {
-          console.log("Successfully fetched podcasts:", response);
-
           if (response && response.items) {
             setPodcasts(
               response.items
@@ -402,19 +741,10 @@ const LibraryTesting = () => {
       });
     }
   };
-
-  /*
-    This pulls the list of the albums that were saved by the current user. It gets the names and the images of 
-    the albums from the response and put them into `setAlbums`.
-
-    Relevant Documentation: https://developer.spotify.com/documentation/web-api/reference/get-users-saved-albums
-  */
   const fetchAlbums = () => {
     if (accessToken) {
       performFetch("https://api.spotify.com/v1/me/albums", {}, accessToken, invalidateAccess)
         .then((response) => {
-          console.log("Successfully fetched albums:", response);
-
           if (response && response.items) {
             setAlbums(
               response.items
@@ -431,19 +761,10 @@ const LibraryTesting = () => {
       });
     }
   };
-
-  /*
-    This pulls the list of the artists that are followed by the current user. It gets the names and 
-    the images of the artiss from the response and put them into `setArtists`.
-
-    Relevant Documentation: https://developer.spotify.com/documentation/web-api/reference/get-followed
-  */
   const fetchArtists = () => {
     if (accessToken) {
       performFetch("https://api.spotify.com/v1/me/following?limit=20", { type: "artist" }, accessToken, invalidateAccess)
         .then((response) => {
-          console.log("Successfully fetched artists:", response);
-
           if (response && response.artists && response.artists.items) {
             setArtists(
               response.artists.items
@@ -471,14 +792,10 @@ const LibraryTesting = () => {
     }
   }, [accessToken]);
 
-  // TODO: Backend - Add these states and effects for API integration:
-  // const [loading, setLoading] = useState(true);
-  // const { accessToken } = useContext(SpotifyAuthContext);
-  // useEffect(() => { fetch Spotify data here }, [accessToken]);
-
+  // --- Render Logic ---
   return (
     <>
-      {/* Fixed-position gradient that stays at bottom of viewport */}
+      {/* Fixed-position gradient */}
       <div style={{
         position: 'fixed',
         bottom: 0,
@@ -486,7 +803,7 @@ const LibraryTesting = () => {
         right: 0,
         width: '100%',
         height: '180px',
-        zIndex: 999,
+        zIndex: 5,
         pointerEvents: 'none',
         margin: 0,
         padding: 0,
@@ -494,9 +811,9 @@ const LibraryTesting = () => {
         <AnimatedBlob
           colors={colors}
           style={{
-            width: '100%', // Back to 100%
+            width: '100%',
             height: '100%',
-            filter: 'blur(70px)', // Back to original blur amount
+            filter: 'blur(70px)',
             opacity: 0.75,
             position: 'absolute',
             top: 0,
@@ -507,8 +824,12 @@ const LibraryTesting = () => {
         />
       </div>
 
-      {/* Your existing content */}
-      <div style={{ position: 'relative' }}>
+      {/* Main container */}
+      <div style={{ 
+        position: 'relative',
+        minHeight: '100vh',
+        overflow: 'visible',
+      }}>
         <div style={{
           backgroundImage: `url(${backgroundPng})`,
           backgroundSize: 'cover',
@@ -518,22 +839,16 @@ const LibraryTesting = () => {
           minHeight: '100vh',
           padding: '0',
           perspective: '1000px',
-          overflow: 'hidden',
+          overflow: 'visible',
           position: 'relative',
-          zIndex: 1
+          zIndex: 1,
         }}>
-          {/* Content container */}
+          {/* Content container with continuous flow */}
           <div style={{
-            paddingTop: '120px',
-            paddingBottom: '40px',
-            paddingLeft: '20px',
-            paddingRight: '20px',
-            overflowY: 'auto',
-            height: '100vh',
             position: 'relative',
-            zIndex: 3,
-            overscrollBehavior: 'none',
-            boxSizing: 'border-box'
+            paddingTop: '10vh', // Initial top padding
+            overflow: 'visible',
+            zIndex: 900,
           }}>
             {sections.map((section, index) => (
               <LibrarySection


### PR DESCRIPTION
⚠️ This is a very large PR with many new additions. This is a big moment for Juke and includes a long-dreamt of feature back in the early days of our mockups: a curved slider. The iPod [Cover Flow](https://www.reddit.com/r/ipod/comments/1fmsftu/what_is_better_than_cover_flow_man_coolest_music/) nostalgia is real.

# What’s this about?
This PR polishes the playback experience, tightens Library spacing, and hardens player connectivity. It introduces smooth cross‑fade animations for track changes, adds clearer navigation cues, and eliminates several edge‑case crashes and API‑rate‑limit failures.

# What’s changed?
## UI / UX
### Home.js
- Smooth fade‑in / fade‑out animations for song title, artist, and album art on every track change.
- Standardised animation timing to match Library.
### Library.js
- Semi‑transparent navigation arrows on scroll wheels that brighten on hover.
- Matching animated gradient footer for seamless visual hand‑off from Home.
- Persistent shimmer highlight on the currently‑playing track that survives page navigation.
- Top padding reduced 10 vh → 5 vh; section spacing 35 vh → 15 vh; title margin 8 vh → 4 vh for a tighter layout.
### Player logic
- Robust device‑initialisation state machine with clearer error surfacing.
- Improved state persistence and automatic device activation after reconnect.
- Proper cleanup of listeners on player disconnect to prevent memory leaks.
- Initialization‑state tracking to remove race conditions.

# Result
- Track changes feel fluid and flicker‑free.
- Library navigation is clearer and takes up less vertical space.
- Player remains connected, recovers automatically from network hiccups, and surfaces meaningful errors instead of crashing.

# Testing
- [ ] Scroll Library wheels; verify arrows appear, animate on hover, and scrolling stays smooth.
- [ ] Play tracks with rapid skips; confirm title/artist/artwork fade correctly and gradient footer updates.
- [ ] Navigate away and back; shimmer highlight should persist on the active track.
- [ ] Disconnect/reconnect playback device; ensure listeners are not duplicated and playback resumes.
- [ ] Resize the window from mobile to desktop; spacing and responsiveness should hold.

Closes issue https://github.com/tennitech/juke/issues/33.